### PR TITLE
Added meta data to API call

### DIFF
--- a/includes/lnc_api.php
+++ b/includes/lnc_api.php
@@ -20,12 +20,14 @@ class LightningCheckoutAPI {
     }
 
     public function generateInvoice($amount, $memo) {
+        $fiat_currency = "EUR";
         $data = array(
             "out" => false,
             "amount" => $amount,
             "memo" => $memo,
-            "unit" => "eur",
-            "webhook" => $this->webhook_url
+            "unit" => $fiat_currency,
+            "webhook" => $this->webhook_url,
+            "extra": {"lnc_product": "BTCWEBSHOP", "lnc_fiat_amount": $amount, "lnc_fiat_currency": $fiat_currency}
         );
         $headers = array(
             'accept' => 'application/json',

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -89,7 +89,7 @@ function lightning_payment_shortcode($atts = []) {
     $amount = getFloatValueFromString($atts['amount']);
 
     $api = new LightningCheckoutAPI(LNC_API_KEY, LNC_URL, LNC_WEBHOOK_URL);
-    $invoiceData = $api->generateInvoice($amount, $atts['description'] . " (" . $amount . " EUR)");
+    $invoiceData = $api->generateInvoice($amount, $atts['description']);
 
     enqueue_payment_script($atts['returnurl'], $invoiceData);
 


### PR DESCRIPTION
When metadata is added in API call, it's not needed anymore in description. 
So it can be removed there as well, if not needed for another purpose. 